### PR TITLE
CompositeContainer implements correct writable interface

### DIFF
--- a/src/CompositeContainer.php
+++ b/src/CompositeContainer.php
@@ -3,6 +3,7 @@
 namespace Dhii\Di;
 
 use Exception;
+use Interop\Container\ContainerInterface as BaseContainerInterface;
 
 /**
  * Concrete implementation of a container that can have child containers.
@@ -11,7 +12,7 @@ use Exception;
  */
 class CompositeContainer extends AbstractCompositeContainer implements
     ParentAwareContainerInterface,
-    CompositeContainerInterface
+    WritableCompositeContainerInterface
 {
     /**
      * Constructor.
@@ -70,11 +71,11 @@ class CompositeContainer extends AbstractCompositeContainer implements
      *
      * @since 0.1
      *
-     * @param ContainerInterface $container The container to add.
+     * @param BaseContainerInterface $container The container to add.
      *
      * @return $this This instance.
      */
-    public function add(ContainerInterface $container)
+    public function add(BaseContainerInterface $container)
     {
         $this->_add($container);
 

--- a/test/functional/CompositeContainerTest.php
+++ b/test/functional/CompositeContainerTest.php
@@ -77,6 +77,23 @@ class CompositeContainerTest extends TestCase
     }
 
     /**
+     * Creates an instance of the most basic interop container.
+     *
+     * @since [*next-version*]
+     *
+     * @return ContainerInterface The new instance.
+     */
+    public function createBaseContainer()
+    {
+        $instance = $this->mock('Interop\\Container\\ContainerInterface')
+                ->get()
+                ->has()
+                ->new();
+
+        return $instance;
+    }
+
+    /**
      * Create a service definition that returns a simple value.
      *
      * @since 0.1
@@ -90,6 +107,34 @@ class CompositeContainerTest extends TestCase
         return function(ContainerInterface $container, $previous = null) use ($value) {
             return $value;
         };
+    }
+
+    /**
+     * Tests whether a valid instance of the test subject can be created.
+     *
+     * @since [*next-version*]
+     */
+    public function testCanBeCreated()
+    {
+        $subject = $this->createInstance();
+        $this->assertInstanceOf('Dhii\\Di\\CompositeContainerInterface', $subject, 'A valid instance of the test subject could not be created');
+        $this->assertInstanceOf('Dhii\\Di\\WritableCompositeContainerInterface', $subject, 'Test subject does not implement required interface');
+        $this->assertInstanceOf('Dhii\\Di\\ParentAwareContainerInterface', $subject, 'Test subject does not implement required interface');
+        $this->assertInstanceOf('Interop\\Container\\ContainerInterface', $subject, 'Test subject does not implement required interface');
+    }
+
+    /**
+     * Tests whether an interop container can get added to the composite container.
+     *
+     * @since [*next-version*]
+     */
+    public function testAdd()
+    {
+        $subject = $this->createInstance();
+        $child = $this->createBaseContainer();
+
+        $subject->add($child);
+        $this->assertContains($child, $subject->getContainers(), 'Added container is not in the resulting container set');
     }
 
     /**


### PR DESCRIPTION
`CompositeContainer#add()` now implements `WritableCompositeContainerInterface::add()`.

Aims to incorporate solution for #4.