### PR TITLE
CompositeContainer constructor now accepts interop container

### DIFF
--- a/src/CompositeContainer.php
+++ b/src/CompositeContainer.php
@@ -19,9 +19,9 @@ class CompositeContainer extends AbstractCompositeContainer implements
      *
      * @since 0.1
      *
-     * @param ContainerInterface $parent The parent container of this instance.
+     * @param BaseContainerInterface $parent The parent container of this instance.
      */
-    public function __construct(ContainerInterface $parent = null)
+    public function __construct(BaseContainerInterface $parent = null)
     {
         $this->_setParentContainer($parent);
     }

--- a/test/functional/CompositeContainerTest.php
+++ b/test/functional/CompositeContainerTest.php
@@ -138,6 +138,20 @@ class CompositeContainerTest extends TestCase
     }
 
     /**
+     * Tests that the constructor accepts correct args.
+     *
+     * @since [*next-version*]
+     */
+    public function testConstructor()
+    {
+        $class = static::TEST_SUBJECT_CLASSNAME;
+        $parent = $this->createBaseContainer();
+        $subject = $this->createInstance($parent);
+
+        $this->assertSame($parent, $subject->getParentContainer(), 'Parent set in constructor could not be retrieved');
+    }
+
+    /**
      * Tests whether services of child containers can be correctly retrieved from parent.
      * No relationships between services.
      *


### PR DESCRIPTION
CompositeContainer constructor now accepts the correct interface.

Aims to incorporate solution for #5.