### PR TITLE
Fixes CompositeContainer's use of exceptions

### DIFF
--- a/src/CompositeContainer.php
+++ b/src/CompositeContainer.php
@@ -3,6 +3,8 @@
 namespace Dhii\Di;
 
 use Exception;
+use Dhii\Di\Exception\ContainerException;
+use Dhii\Di\Exception\NotFoundException;
 use Interop\Container\ContainerInterface as BaseContainerInterface;
 
 /**

--- a/test/functional/CompositeContainerTest.php
+++ b/test/functional/CompositeContainerTest.php
@@ -3,6 +3,8 @@
 namespace Dhii\Di\FuncTest;
 
 use Dhii\Di\CompositeContainer;
+use Dhii\Di\Exception\NotFoundException;
+use Dhii\Di\Exception\ContainerException;
 use Dhii\Di\ParentAwareContainerInterface;
 use Dhii\Di\ServiceProvider as ServiceProvider2;
 use Interop\Container\ContainerInterface;
@@ -336,5 +338,35 @@ class CompositeContainerTest extends TestCase
         }
 
         $this->assertEquals($expected, $actual, 'The container structure did not resolve services correctly');
+    }
+
+    /**
+     * Tests the method that creates a {@see NotFoundException}.
+     *
+     * @since [*next-version*]
+     */
+    public function testCreateNotFoundException()
+    {
+        $subject = $this->createInstance();
+
+        $expected = new NotFoundException('test message', 3, null);
+        $exception = $subject->this()->_createNotFoundException('test message', 3, null);
+
+        $this->assertEquals($expected, $exception);
+    }
+
+    /**
+     * Tests the method that creates a {@see ContainerException}.
+     *
+     * @since [*next-version*]
+     */
+    public function testContainerException()
+    {
+        $subject = $this->createInstance();
+
+        $expected = new ContainerException('test message', 3, null);
+        $exception = $subject->this()->_createContainerException('test message', 3, null);
+
+        $this->assertEquals($expected, $exception);
     }
 }

--- a/test/functional/CompositeContainerTest.php
+++ b/test/functional/CompositeContainerTest.php
@@ -355,10 +355,16 @@ class CompositeContainerTest extends TestCase
     {
         $subject = $this->createInstance();
 
-        $expected = new NotFoundException('test message', 3, null);
-        $exception = $subject->this()->_createNotFoundException('test message', 3, null);
+        $previous = new \Exception('test message', 3, null);
+        $exception = $subject->this()->_createNotFoundException('test message', 3, $previous);
 
-        $this->assertEquals($expected, $exception);
+        $this->assertInstanceOf('Dhii\\Di\\Exception\\NotFoundException', $exception);
+        $this->assertInstanceOf('Dhii\\Di\\ExceptionInterface', $exception);
+        $this->assertInstanceOf('Interop\\Container\\Exception\\NotFoundException', $exception);
+
+        $this->assertEquals('test message', $exception->getMessage());
+        $this->assertEquals(3, $exception->getCode());
+        $this->assertEquals($previous, $exception->getPrevious());
     }
 
     /**
@@ -370,9 +376,15 @@ class CompositeContainerTest extends TestCase
     {
         $subject = $this->createInstance();
 
-        $expected = new ContainerException('test message', 3, null);
-        $exception = $subject->this()->_createContainerException('test message', 3, null);
+        $previous = new \Exception('test message', 3, null);
+        $exception = $subject->this()->_createContainerException('test message', 3, $previous);
 
-        $this->assertEquals($expected, $exception);
+        $this->assertInstanceOf('Dhii\\Di\\Exception\\ContainerException', $exception);
+        $this->assertInstanceOf('Dhii\\Di\\ExceptionInterface', $exception);
+        $this->assertInstanceOf('Interop\\Container\\Exception\\ContainerException', $exception);
+
+        $this->assertEquals('test message', $exception->getMessage());
+        $this->assertEquals(3, $exception->getCode());
+        $this->assertEquals($previous, $exception->getPrevious());
     }
 }

--- a/test/functional/CompositeContainerTest.php
+++ b/test/functional/CompositeContainerTest.php
@@ -61,9 +61,9 @@ class CompositeContainerTest extends TestCase
      *
      * @since 0.1
      *
-     * @param ServiceProvider $definitions The service provider.
-     * @param ContainerInterface $parent The container instance which is the be the parent container.
-     * @param bool $isMutable If true, the container will have its parent container be mutable; immutable if false.
+     * @param ServiceProvider    $definitions The service provider.
+     * @param ContainerInterface $parent      The container instance which is the be the parent container.
+     * @param bool               $isMutable   If true, the container will have its parent container be mutable; immutable if false.
      *
      * @return ParentAwareContainerInterface
      */
@@ -106,7 +106,7 @@ class CompositeContainerTest extends TestCase
      */
     public function createDefinition($value)
     {
-        return function(ContainerInterface $container, $previous = null) use ($value) {
+        return function (ContainerInterface $container, $previous = null) use ($value) {
             return $value;
         };
     }
@@ -164,15 +164,15 @@ class CompositeContainerTest extends TestCase
         $rootContainer = $this->createInstance();
         $childContainer1 = $this->createContainer(
             $this->createServiceProvider(array(
-                'service1'          => $this->createDefinition('service-1'),
-                'service2'          => $this->createDefinition('service-2'),
+                'service1' => $this->createDefinition('service-1'),
+                'service2' => $this->createDefinition('service-2'),
             )), // Servide definitions
             $rootContainer, // Parent
             false // Immutable
         );
         $childContainer2 = $this->createContainer(
             $this->createServiceProvider(array(
-                'service3'          => $this->createDefinition('service-3'),
+                'service3' => $this->createDefinition('service-3'),
             )), // Servide definitions
             $rootContainer, // Parent
             false // Immutable
@@ -181,9 +181,9 @@ class CompositeContainerTest extends TestCase
         $rootContainer->add($childContainer2);
 
         $expected = array(
-            'service1'          => 'service-1',
-            'service2'          => 'service-2',
-            'service3'          => 'service-3',
+            'service1' => 'service-1',
+            'service2' => 'service-2',
+            'service3' => 'service-3',
         );
 
         $actual = array();
@@ -207,11 +207,12 @@ class CompositeContainerTest extends TestCase
 
         $childContainer1 = $this->createContainer(
             $this->createServiceProvider(array(
-                'service1'          => function (ContainerInterface $container) use ($me) {
+                'service1' => function (ContainerInterface $container) use ($me) {
                     $me->assertInstanceOf('Dhii\Di\CompositeContainerInterface', $container, 'Container must be composite in order to retrieve definition from another container');
+
                     return implode('->', array('service-1', $container->get('service3')));
                 },
-                'service2'          => $this->createDefinition('service-2'),
+                'service2' => $this->createDefinition('service-2'),
             )), // Servide definitions
             $rootContainer, // Parent
             false // Immutable
@@ -220,7 +221,7 @@ class CompositeContainerTest extends TestCase
 
         $childContainer2 = $this->createContainer(
             $this->createServiceProvider(array(
-                'service3'          => $this->createDefinition('service-3'),
+                'service3' => $this->createDefinition('service-3'),
             )), // Servide definitions
             $rootContainer, // Parent
             false // Immutable
@@ -232,9 +233,9 @@ class CompositeContainerTest extends TestCase
         $this->assertEquals(2, count($rootContainer->getContainers()), 'Incorrect number of child containers');
 
         $expected = array(
-            'service1'          => 'service-1->service-3',
-            'service2'          => 'service-2',
-            'service3'          => 'service-3',
+            'service1' => 'service-1->service-3',
+            'service2' => 'service-2',
+            'service3' => 'service-3',
         );
 
         $actual = array();
@@ -259,15 +260,17 @@ class CompositeContainerTest extends TestCase
         $rootContainer = $this->createInstance();
         $childContainer1 = $this->createContainer(
             $this->createServiceProvider(array(
-                'service1'          => $this->createDefinition('service-1'),
-                'service2'          => function (ContainerInterface $c) use ($me) {
+                'service1' => $this->createDefinition('service-1'),
+                'service2' => function (ContainerInterface $c) use ($me) {
                     $me->assertInstanceOf('Dhii\Di\CompositeContainerInterface', $c, 'Container must be composite in order to retrieve definition from another container');
+
                     return implode('->', array('service-2', $c->get('service3')));
                 },
-                'service7'          => function (ContainerInterface $c) use ($me) {
+                'service7' => function (ContainerInterface $c) use ($me) {
                     $me->assertInstanceOf('Dhii\Di\CompositeContainerInterface', $c, 'Container must be composite in order to retrieve definition from another container');
+
                     return implode('->', array('service-7', $c->get('service4')));
-                }
+                },
             )), // Servide definitions
             $rootContainer, // Parent
             false // Immutable
@@ -276,11 +279,12 @@ class CompositeContainerTest extends TestCase
 
         $childContainer2 = $this->createContainer(
             $this->createServiceProvider(array(
-                'service3'          => $this->createDefinition('service-3'),
-                'service4'          => function (ContainerInterface $c) use ($me) {
+                'service3' => $this->createDefinition('service-3'),
+                'service4' => function (ContainerInterface $c) use ($me) {
                     $me->assertInstanceOf('Dhii\Di\CompositeContainerInterface', $c, 'Container must be composite in order to retrieve definition from another container');
+
                     return implode('->', array('service-4', $c->get('service5')));
-                }
+                },
             )), // Servide definitions
             $rootContainer, // Parent
             false // Immutable
@@ -291,25 +295,28 @@ class CompositeContainerTest extends TestCase
         $childContainer3 = $this->createInstance($rootContainer);
         $childContainer3->add($this->createContainer(
             $this->createServiceProvider(array(
-                'service5'          => function (ContainerInterface $c) use ($me) {
+                'service5' => function (ContainerInterface $c) use ($me) {
                     $me->assertInstanceOf('Dhii\Di\CompositeContainerInterface', $c, 'Container must be composite in order to retrieve definition from another container');
+
                     return implode('->', array('service-5', $c->get('service8')));
                 },
-                'service6'          => $this->createDefinition('service-6')
+                'service6' => $this->createDefinition('service-6'),
             )),
             $rootContainer,
             false
         ));
         $childContainer3->add($this->createContainer(
             $this->createServiceProvider(array(
-                'service8'          => function (ContainerInterface $c) use ($me) {
+                'service8' => function (ContainerInterface $c) use ($me) {
                     $me->assertInstanceOf('Dhii\Di\CompositeContainerInterface', $c, 'Container must be composite in order to retrieve definition from another container');
+
                     return implode('->', array('service-8', $c->get('service1')));
                 },
-                'service9'          => function (ContainerInterface $c) use ($me) {
+                'service9' => function (ContainerInterface $c) use ($me) {
                     $me->assertInstanceOf('Dhii\Di\CompositeContainerInterface', $c, 'Container must be composite in order to retrieve definition from another container');
+
                     return implode('->', array('service-9', $c->get('service6')));
-                }
+                },
             )),
             $rootContainer,
             false
@@ -319,17 +326,16 @@ class CompositeContainerTest extends TestCase
         $rootContainer->add($childContainer2);
         $rootContainer->add($childContainer3);
 
-
         $expected = array(
-            'service1'          => 'service-1',
-            'service2'          => 'service-2->service-3',
-            'service3'          => 'service-3',
-            'service4'          => 'service-4->service-5->service-8->service-1',
-            'service5'          => 'service-5->service-8->service-1',
-            'service6'          => 'service-6',
-            'service7'          => 'service-7->service-4->service-5->service-8->service-1',
-            'service8'          => 'service-8->service-1',
-            'service9'          => 'service-9->service-6'
+            'service1' => 'service-1',
+            'service2' => 'service-2->service-3',
+            'service3' => 'service-3',
+            'service4' => 'service-4->service-5->service-8->service-1',
+            'service5' => 'service-5->service-8->service-1',
+            'service6' => 'service-6',
+            'service7' => 'service-7->service-4->service-5->service-8->service-1',
+            'service8' => 'service-8->service-1',
+            'service9' => 'service-9->service-6',
         );
 
         $actual = array();


### PR DESCRIPTION
[`CompositeContainer`] now uses [`NotFoundException`] and [`ContainerException`] correctly.

Aims to incorporate a solution for #9 

[`CompositeContainer`]: https://github.com/Dhii/di/blob/fix/composite-container-incorrect-exceptions_%239/src/CompositeContainer.php

[`ContainerException`]: https://github.com/Dhii/di/blob/fix/composite-container-incorrect-exceptions_%239/src/CompositeContainer.php#L6

[`NotFoundException`]: https://github.com/Dhii/di/blob/fix/composite-container-incorrect-exceptions_%239/src/CompositeContainer.php#L7
